### PR TITLE
Feat/landing page about section

### DIFF
--- a/src/components/Landing/About.vue
+++ b/src/components/Landing/About.vue
@@ -1,12 +1,38 @@
 <template>
-  <div class="container">LANDING Summary</div>
+  <div class="container">
+    <h1 class="title">ABOUT</h1>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </p>
+  </div>
 </template>
-<script></script>
+
+<script>
+export default {
+  name: "AboutSection",
+};
+</script>
+
 <style lang="scss">
 body {
   height: 100vh;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: Arial, sans-serif;
 }
+
 .container {
-  height: 100vh;
+  text-align: center;
+  font-weight: bold;
+}
+
+.title {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: maroon;
 }
 </style>

--- a/src/components/Landing/About.vue
+++ b/src/components/Landing/About.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="about-container">
     <h1 class="title">ABOUT</h1>
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
@@ -16,23 +16,20 @@ export default {
 </script>
 
 <style lang="scss">
-body {
-  height: 100vh;
-  margin: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-family: Arial, sans-serif;
-}
-
-.container {
-  text-align: center;
-  font-weight: bold;
+.about-container {
+  text-align: left;
+  font-weight: 1200;
+  font-family: 'Inter', serif;
+  max-width: 900px; 
+  margin: 0 auto; 
+  padding: 30px; 
 }
 
 .title {
   font-size: 2.5rem;
-  font-weight: bold;
+  font-weight: 800;
   color: maroon;
+  font-family: 'Inter', serif;
+  margin-bottom: 10px; 
 }
 </style>


### PR DESCRIPTION
Made the "ABOUT" bold. Place the info alligned to left. Changed the "container" into "about-container"
<img width="1710" alt="Screenshot 2025-02-03 at 11 58 59 AM" src="https://github.com/user-attachments/assets/76054e00-98b4-4a3a-a351-7b72edda0311" />
